### PR TITLE
fix: address PR #6 review findings

### DIFF
--- a/.github/workflows/build-schema.yml
+++ b/.github/workflows/build-schema.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+          cache: 'pip'
 
       - name: Install dependencies
         run: pip install -r requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+          cache: 'pip'
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Validate JSON against bootstrap schema

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+          cache: 'pip'
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Pre-flight validation (Markdown)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-jsonschema>=4.20.0
-blake3>=1.0.0
+jsonschema==4.26.0
+blake3==1.0.8

--- a/rules/core/NTE.json
+++ b/rules/core/NTE.json
@@ -8,14 +8,14 @@
   "rule_set": {
     "version": "0.1.0",
     "timestamp": "2026-03-21T00:00:00Z",
-    "hash": "blake3:d809834268f6a94a15d4819b283e32c03d0c44f0d59c9f8a561c97d3c2f73919"
+    "hash": "blake3:8ed20e9f5149db3aaffcb28607c6a0806bd6cfaaeecfefae2fc2be2c18c2e9ea"
   },
   "rules": [
     {
       "id": "NTE-001",
       "revision": 0,
       "state": "D",
-      "body": "IS associated with a single rule and must reference the rule's identifier explicitly.",
+      "body": "IS associated with a single rule and must reference the rule's identifier explicitly (e.g., [<rule id>/<incremental note id (OOn)]).",
       "added_by": "@pleberre",
       "added_at": "2026-03-07",
       "supersedes": null

--- a/rules/core/_schema/entity.v1.schema.json
+++ b/rules/core/_schema/entity.v1.schema.json
@@ -55,7 +55,7 @@
         },
         "timestamp": {
           "type": "string",
-          "pattern": "^\\d{4}-\\d{2}-\\d{2}T"
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}"
         },
         "hash": {
           "oneOf": [
@@ -113,7 +113,7 @@
           },
           "added_at": {
             "type": "string",
-            "pattern": "^\\d{4}-\\d{2}-\\d{2}"
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
           },
           "supersedes": {
             "oneOf": [
@@ -184,7 +184,7 @@
           },
           "added_at": {
             "type": "string",
-            "pattern": "^\\d{4}-\\d{2}-\\d{2}"
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
           },
           "revision": {
             "type": "integer",

--- a/tools/build-schema.py
+++ b/tools/build-schema.py
@@ -140,12 +140,10 @@ def extract_constraints(
         if m:
             constraints["minLength"] = int(m.group(1))
             constraints["maxLength"] = int(m.group(2))
-            continue
 
         # Alphanumeric pattern
         if RE_ALPHANUMERIC.search(body):
             constraints["pattern"] = "^[a-zA-Z0-9]+$"
-            continue
 
         # State enum
         m = RE_STATE_ENUM.search(body)
@@ -154,17 +152,14 @@ def extract_constraints(
             states = re.findall(r"\(([A-Z])\)", m.group(1))
             if states:
                 constraints["enum"] = states
-            continue
 
         # Semver
         if RE_SEMVER.search(body):
             constraints["pattern"] = SEMVER_PATTERN
-            continue
 
         # Blake3
         if RE_BLAKE3.search(body):
             constraints["pattern"] = "^blake3:[a-f0-9]{64}$"
-            continue
 
         # Rules that define required fields (HAS, IS associated) or
         # optional fields (MAY) are handled structurally, not via
@@ -275,7 +270,7 @@ def build_schema(
             "state": state_schema,
             "body": {"type": "string", "minLength": 1},
             "added_by": {"type": "string", "minLength": 1},
-            "added_at": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}"},
+            "added_at": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$"},
             "supersedes": {
                 "oneOf": [
                     {"type": "string", "pattern": "^[A-Z0-9]+-\\d{3}$"},
@@ -304,7 +299,7 @@ def build_schema(
             "type": note_type_schema,
             "content": {"type": "string", "minLength": 1},
             "added_by": {"type": "string", "minLength": 1},
-            "added_at": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}"},
+            "added_at": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$"},
             "revision": {"type": "integer", "minimum": 0},
         },
         "additionalProperties": False,
@@ -341,7 +336,7 @@ def build_schema(
                     "version": version_schema,
                     "timestamp": {
                         "type": "string",
-                        "pattern": "^\\d{4}-\\d{2}-\\d{2}T",
+                        "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}",
                     },
                     "hash": hash_schema,
                 },
@@ -360,7 +355,14 @@ def build_schema(
 def validate_full(
     files: list[tuple[Path, dict]], schema: dict
 ) -> bool:
-    """Validate all core JSON files against the generated schema."""
+    """Validate all core JSON files against the generated schema.
+
+    NOTE: This validation is circular by design — the schema is derived from
+    the same files it validates. It catches structural inconsistencies (e.g.,
+    a rule body claiming 6 states but a file using a 7th), but it cannot
+    detect constraint *regression* (e.g., reducing allowed states from 6 to 2).
+    Regression detection belongs in the PR validator (rule-diff, spec §7.2).
+    """
     validator = Draft202012Validator(schema)
     all_ok = True
 


### PR DESCRIPTION
## Summary

- Restore truncated NTE-001 body with note ID format example (data loss fix)
- Add end anchors (`$`) to date/timestamp schema patterns (schema too permissive)
- Remove early-exit `continue` in constraint extraction (latent bug)
- Pin dependency versions in requirements.txt (reproducibility)
- Add pip caching to all CI/CD workflows (performance)
- Regenerate schema and recompute hashes

## Context

These are fixes from the critical review of PR #6. See plan for full details.

## Test plan

- [x] `python3 tools/build-schema.py --check` — schema matches
- [x] `python3 tools/compute-hash.py` — all hashes valid
- [x] `python3 scripts/validate-rules.py` — markdown validation passes
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)