### PR TITLE
feat: add Python linting with Ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,21 @@ jobs:
         with:
           configFile: .commitlintrc.yml
 
+  lint-python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install Ruff
+        run: pip install ruff
+      - name: Ruff lint
+        run: ruff check .
+      - name: Ruff format check
+        run: ruff format --check .
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,14 @@ repos:
     hooks:
       - id: editorconfig-checker
 
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.10
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+        args: [--check]
+
   - repo: local
     hooks:
       - id: validate-rules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.ruff]
+target-version = "py312"
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "B", "SIM", "RUF"]

--- a/scripts/validate-rules.py
+++ b/scripts/validate-rules.py
@@ -48,10 +48,7 @@ def validate_file(path: Path, seen_ids: dict[str, Path]) -> list[str]:
 
         # Duplicate ID check
         if rule_id in seen_ids:
-            errors.append(
-                f"{path}:{lineno}: duplicate rule ID [{rule_id}] "
-                f"(first seen in {seen_ids[rule_id]})"
-            )
+            errors.append(f"{path}:{lineno}: duplicate rule ID [{rule_id}] (first seen in {seen_ids[rule_id]})")
         else:
             seen_ids[rule_id] = path
 

--- a/tools/build-schema.py
+++ b/tools/build-schema.py
@@ -21,7 +21,7 @@ import re
 import sys
 from pathlib import Path
 
-from jsonschema import Draft202012Validator, ValidationError
+from jsonschema import Draft202012Validator
 
 ROOT = Path(__file__).parent.parent
 CORE_DIR = ROOT / "rules" / "core"
@@ -45,17 +45,13 @@ ENTITY_SCHEMA_MAP = {
 # --- Constraint extraction patterns ---
 
 # "MUST have a length of at least N and at most M characters"
-RE_LENGTH = re.compile(
-    r"MUST have a length of at least (\d+) and at most (\d+) characters"
-)
+RE_LENGTH = re.compile(r"MUST have a length of at least (\d+) and at most (\d+) characters")
 
 # "IS a string of letters or numbers only"
 RE_ALPHANUMERIC = re.compile(r"IS a string of letters or numbers only")
 
 # "MAY have a state: X (C), Y (C), ..."
-RE_STATE_ENUM = re.compile(
-    r"MAY have a state:\s*(.+)"
-)
+RE_STATE_ENUM = re.compile(r"MAY have a state:\s*(.+)")
 
 # "MUST be in the semantic versioning format"
 RE_SEMVER = re.compile(r"MUST be in the semantic versioning format")
@@ -117,16 +113,12 @@ def collect_rules_by_entity(
             # Handle nested sub-entities (depth 2)
             for subsub in sub.get("sub_entities", []):
                 ssid = subsub["entity"]["id"]
-                result.setdefault((eid, ssid), []).extend(
-                    subsub.get("rules", [])
-                )
+                result.setdefault((eid, ssid), []).extend(subsub.get("rules", []))
 
     return result
 
 
-def extract_constraints(
-    rules: list[dict], schema_path: str
-) -> dict:
+def extract_constraints(rules: list[dict], schema_path: str) -> dict:
     """Extract JSON Schema constraints from rule bodies."""
     constraints: dict = {}
     warnings: list[str] = []
@@ -164,13 +156,8 @@ def extract_constraints(
         # Rules that define required fields (HAS, IS associated) or
         # optional fields (MAY) are handled structurally, not via
         # pattern extraction. Log unmatched for visibility.
-        if not any(
-            kw in body
-            for kw in ["HAS", "IS ", "DEFINES", "MUST", "MAY", "Once"]
-        ):
-            warnings.append(
-                f"  WARNING: {rule_id} → no constraint extracted: {body[:60]}..."
-            )
+        if not any(kw in body for kw in ["HAS", "IS ", "DEFINES", "MUST", "MAY", "Once"]):
+            warnings.append(f"  WARNING: {rule_id} → no constraint extracted: {body[:60]}...")
 
     for w in warnings:
         print(w)
@@ -352,9 +339,7 @@ def build_schema(
     return entity_file_schema
 
 
-def validate_full(
-    files: list[tuple[Path, dict]], schema: dict
-) -> bool:
+def validate_full(files: list[tuple[Path, dict]], schema: dict) -> bool:
     """Validate all core JSON files against the generated schema.
 
     NOTE: This validation is circular by design — the schema is derived from
@@ -394,8 +379,7 @@ def main() -> int:
     print(f"\nPhase 3: Self-validation ({len(files)} files)")
     if not validate_full(files, schema):
         print(
-            "\nERROR: Generated schema rejects core files. "
-            "This indicates an incoherent rule change.",
+            "\nERROR: Generated schema rejects core files. This indicates an incoherent rule change.",
             file=sys.stderr,
         )
         return 1
@@ -410,15 +394,13 @@ def main() -> int:
                 return 0
             else:
                 print(
-                    "\nERROR: Committed schema is stale. "
-                    "Run 'python3 tools/build-schema.py' and commit the result.",
+                    "\nERROR: Committed schema is stale. Run 'python3 tools/build-schema.py' and commit the result.",
                     file=sys.stderr,
                 )
                 return 1
         else:
             print(
-                "\nERROR: Schema file does not exist. "
-                "Run 'python3 tools/build-schema.py' to generate it.",
+                "\nERROR: Schema file does not exist. Run 'python3 tools/build-schema.py' to generate it.",
                 file=sys.stderr,
             )
             return 1

--- a/tools/compute-hash.py
+++ b/tools/compute-hash.py
@@ -36,7 +36,7 @@ def compute_hash(data: dict) -> str:
 
 def process_file(path: Path) -> bool:
     """Compute and update hash in a single entity file. Returns True if changed."""
-    with open(path, "r", encoding="utf-8") as f:
+    with open(path, encoding="utf-8") as f:
         data = json.load(f)
 
     new_hash = compute_hash(data)


### PR DESCRIPTION
## Summary

- Add Ruff as Python linter and formatter (replaces flake8/isort/pylint)
- Configure via `pyproject.toml` with rule sets: E, F, W, I, UP, B, SIM, RUF
- Add `ruff` and `ruff-format` pre-commit hooks
- Add `lint-python` CI job to `ci.yml`
- Fix 2 existing lint violations and apply consistent formatting

## Test plan

- [x] `ruff check .` — all files pass
- [x] `ruff format --check .` — all files formatted
- [x] `python3 tools/build-schema.py --check` — schema still valid
- [x] `python3 scripts/validate-rules.py` — rules validation passes
- [ ] CI `lint-python` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)