### PR TITLE
feat: add optional source field to realm dependency schema

### DIFF
--- a/rules/core/_schema/realm.v1.schema.json
+++ b/rules/core/_schema/realm.v1.schema.json
@@ -35,7 +35,11 @@
         "required": ["realm_id", "version"],
         "properties": {
           "realm_id": { "type": "string" },
-          "version": { "type": "string" }
+          "version": { "type": "string" },
+          "source": {
+            "type": "string",
+            "description": "Fetch location for this dependency (e.g. github://owner/repo@version/path)"
+          }
         },
         "additionalProperties": false
       }


### PR DESCRIPTION
## Summary

- Adds an optional `source` string field to the dependency object in the realm v1 schema (`rules/core/_schema/realm.v1.schema.json`)
- The field allows specifying a fetch location for a dependency (e.g. `github://owner/repo@version/path`)
- The field is not in `required`, so existing manifests remain valid

Closes #30

## Test plan

- [ ] Validate that existing `realm.json` files still pass schema validation (no required field added)
- [ ] Validate that a `realm.json` with a `source` field in a dependency entry passes validation
- [ ] Validate that invalid `source` values (non-string) are rejected