### PR TITLE
fix: add config schema copy to publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,8 @@ jobs:
           cp rules/core/_schema/bootstrap.schema.json www/schemas/entity/bootstrap.json
           mkdir -p www/schemas/realm
           cp rules/core/_schema/realm.v1.schema.json www/schemas/realm/v1.json
+          mkdir -p www/schemas/config
+          cp rules/core/_schema/config.v1.schema.json www/schemas/config/v1.json
 
       - name: Copy versioned rules
         run: |


### PR DESCRIPTION
## Summary

- Adds `schemas/config/v1.json` to the "Copy schemas" step of the publish job
- The SPCFG entity (added in v1.4.0) generates `config.v1.schema.json`, which manifests reference — but the copy step was never updated
- The schema has been backfilled manually to strspc-www; this ensures future releases publish it automatically