### PR TITLE
chore: release — replace inline Python validation with strspc-cli + strspc-manager

### DIFF
--- a/.github/actions/setup-strspc/action.yml
+++ b/.github/actions/setup-strspc/action.yml
@@ -7,11 +7,11 @@ inputs:
   cli-version:
     description: strspc-cli version to install
     required: false
-    default: "1.14.0"
+    default: "1.14.1"
   manager-version:
     description: strspc-manager version to install
     required: false
-    default: "1.14.0"
+    default: "1.14.1"
 
 runs:
   using: composite

--- a/.github/actions/setup-strspc/action.yml
+++ b/.github/actions/setup-strspc/action.yml
@@ -1,15 +1,20 @@
 name: Setup SteerSpec CLI tools
 description: >
   Download and install strspc-cli and strspc-manager binaries
-  from GitHub Releases. Fails immediately if either download fails.
+  from GitHub Releases with checksum verification.
+  Fails immediately if download or verification fails.
 
 inputs:
   cli-version:
-    description: strspc-cli version to install
+    description: >
+      strspc-cli version to install (bare semver without leading "v",
+      e.g. "1.14.1")
     required: false
     default: "1.14.1"
   manager-version:
-    description: strspc-manager version to install
+    description: >
+      strspc-manager version to install (bare semver without leading "v",
+      e.g. "1.14.1")
     required: false
     default: "1.14.1"
 
@@ -19,20 +24,50 @@ runs:
     - name: Install strspc-cli
       shell: bash
       run: |
+        set -euo pipefail
         VERSION="${{ inputs.cli-version }}"
-        URL="https://github.com/SteerSpec/strspc-cli/releases/download/v${VERSION}/strspc-CLI_${VERSION}_linux_amd64.tar.gz"
+        ARCHIVE="strspc-CLI_${VERSION}_linux_amd64.tar.gz"
+        BASE_URL="https://github.com/SteerSpec/strspc-cli/releases/download/v${VERSION}"
+
+        TMP="$(mktemp -d)"
+        curl -fsSL "${BASE_URL}/${ARCHIVE}" -o "${TMP}/${ARCHIVE}"
+        curl -fsSL "${BASE_URL}/strspc-CLI_${VERSION}_checksums.txt" -o "${TMP}/checksums.txt"
+
+        EXPECTED="$(grep "  ${ARCHIVE}$" "${TMP}/checksums.txt" | cut -d' ' -f1)"
+        if [ -z "$EXPECTED" ]; then
+          echo "::error::Checksum entry not found for ${ARCHIVE}" >&2
+          exit 1
+        fi
+        echo "${EXPECTED}  ${TMP}/${ARCHIVE}" | sha256sum -c -
+
         mkdir -p "$HOME/.local/bin"
-        curl -fsSL "$URL" | tar -xz -C "$HOME/.local/bin"
+        tar -xzf "${TMP}/${ARCHIVE}" -C "$HOME/.local/bin"
         chmod +x "$HOME/.local/bin/strspc"
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        rm -rf "$TMP"
 
     - name: Install strspc-manager
       shell: bash
       run: |
+        set -euo pipefail
         VERSION="${{ inputs.manager-version }}"
-        URL="https://github.com/SteerSpec/strspc-manager/releases/download/v${VERSION}/strspc-manager_${VERSION}_linux_amd64.tar.gz"
-        curl -fsSL "$URL" | tar -xz -C "$HOME/.local/bin"
+        ARCHIVE="strspc-manager_${VERSION}_linux_amd64.tar.gz"
+        BASE_URL="https://github.com/SteerSpec/strspc-manager/releases/download/v${VERSION}"
+
+        TMP="$(mktemp -d)"
+        curl -fsSL "${BASE_URL}/${ARCHIVE}" -o "${TMP}/${ARCHIVE}"
+        curl -fsSL "${BASE_URL}/checksums.txt" -o "${TMP}/checksums.txt"
+
+        EXPECTED="$(grep "  ${ARCHIVE}$" "${TMP}/checksums.txt" | cut -d' ' -f1)"
+        if [ -z "$EXPECTED" ]; then
+          echo "::error::Checksum entry not found for ${ARCHIVE}" >&2
+          exit 1
+        fi
+        echo "${EXPECTED}  ${TMP}/${ARCHIVE}" | sha256sum -c -
+
+        tar -xzf "${TMP}/${ARCHIVE}" -C "$HOME/.local/bin"
         chmod +x "$HOME/.local/bin/strspc-manager"
+        rm -rf "$TMP"
 
     - name: Verify installations
       shell: bash

--- a/.github/actions/setup-strspc/action.yml
+++ b/.github/actions/setup-strspc/action.yml
@@ -1,0 +1,41 @@
+name: Setup SteerSpec CLI tools
+description: >
+  Download and install strspc-cli and strspc-manager binaries
+  from GitHub Releases. Fails immediately if either download fails.
+
+inputs:
+  cli-version:
+    description: strspc-cli version to install
+    required: false
+    default: "1.14.0"
+  manager-version:
+    description: strspc-manager version to install
+    required: false
+    default: "1.14.0"
+
+runs:
+  using: composite
+  steps:
+    - name: Install strspc-cli
+      shell: bash
+      run: |
+        VERSION="${{ inputs.cli-version }}"
+        URL="https://github.com/SteerSpec/strspc-cli/releases/download/v${VERSION}/strspc-CLI_${VERSION}_linux_amd64.tar.gz"
+        mkdir -p "$HOME/.local/bin"
+        curl -fsSL "$URL" | tar -xz -C "$HOME/.local/bin"
+        chmod +x "$HOME/.local/bin/strspc"
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+    - name: Install strspc-manager
+      shell: bash
+      run: |
+        VERSION="${{ inputs.manager-version }}"
+        URL="https://github.com/SteerSpec/strspc-manager/releases/download/v${VERSION}/strspc-manager_${VERSION}_linux_amd64.tar.gz"
+        curl -fsSL "$URL" | tar -xz -C "$HOME/.local/bin"
+        chmod +x "$HOME/.local/bin/strspc-manager"
+
+    - name: Verify installations
+      shell: bash
+      run: |
+        strspc version
+        strspc-manager version

--- a/.github/actions/setup-strspc/action.yml
+++ b/.github/actions/setup-strspc/action.yml
@@ -33,7 +33,7 @@ runs:
         curl -fsSL "${BASE_URL}/${ARCHIVE}" -o "${TMP}/${ARCHIVE}"
         curl -fsSL "${BASE_URL}/strspc-CLI_${VERSION}_checksums.txt" -o "${TMP}/checksums.txt"
 
-        EXPECTED="$(grep "  ${ARCHIVE}$" "${TMP}/checksums.txt" | cut -d' ' -f1)"
+        EXPECTED="$(grep "  ${ARCHIVE}$" "${TMP}/checksums.txt" | cut -d' ' -f1 || true)"
         if [ -z "$EXPECTED" ]; then
           echo "::error::Checksum entry not found for ${ARCHIVE}" >&2
           exit 1
@@ -58,7 +58,7 @@ runs:
         curl -fsSL "${BASE_URL}/${ARCHIVE}" -o "${TMP}/${ARCHIVE}"
         curl -fsSL "${BASE_URL}/checksums.txt" -o "${TMP}/checksums.txt"
 
-        EXPECTED="$(grep "  ${ARCHIVE}$" "${TMP}/checksums.txt" | cut -d' ' -f1)"
+        EXPECTED="$(grep "  ${ARCHIVE}$" "${TMP}/checksums.txt" | cut -d' ' -f1 || true)"
         if [ -z "$EXPECTED" ]; then
           echo "::error::Checksum entry not found for ${ARCHIVE}" >&2
           exit 1

--- a/.github/workflows/build-schema.yml
+++ b/.github/workflows/build-schema.yml
@@ -23,6 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: ./.github/actions/setup-strspc
+
+      - name: Validate realm and entity files
+        run: strspc-manager realm-lint rules/core/
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -32,61 +37,5 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
-      - name: Validate entity JSONs against bootstrap schema
-        run: |
-          python3 -c "
-          import json
-          from jsonschema import validate
-          from pathlib import Path
-          schema = json.loads(Path('rules/core/_schema/bootstrap.schema.json').read_text())
-          files = sorted(f for f in Path('rules/core').glob('*.json') if f.name != 'realm.json')
-          for f in files:
-              validate(instance=json.loads(f.read_text()), schema=schema)
-              print(f'  OK: {f.name}')
-          print(f'Bootstrap: {len(files)} files valid')
-          "
-      - name: Validate realm.json against realm schema
-        run: |
-          python3 -c "
-          import json
-          from jsonschema import validate
-          from pathlib import Path
-          schema = json.loads(Path('rules/core/_schema/realm.v1.schema.json').read_text())
-          data = json.loads(Path('rules/core/realm.json').read_text())
-          validate(instance=data, schema=schema)
-          print('  OK: realm.json')
-          "
-
       - name: Verify schema is not stale
         run: python3 tools/build-schema.py --check
-
-      - name: Verify Blake3 hashes
-        run: |
-          python3 -c "
-          import json
-          from pathlib import Path
-          import blake3
-
-          def canonical_for_hash(data):
-              obj = json.loads(json.dumps(data, sort_keys=True))
-              if 'rule_set' in obj and 'hash' in obj['rule_set']:
-                  obj['rule_set']['hash'] = None
-              for sub in obj.get('sub_entities', []):
-                  if 'rule_set' in sub and 'hash' in sub['rule_set']:
-                      sub['rule_set']['hash'] = None
-              return json.dumps(obj, sort_keys=True, separators=(',', ':')).encode()
-
-          files = sorted(f for f in Path('rules/core').glob('*.json') if f.name != 'realm.json')
-          for f in files:
-              data = json.loads(f.read_text())
-              stored = data.get('rule_set', {}).get('hash')
-              if stored is None:
-                  print(f'  SKIP: {f.name} (hash is null)')
-                  continue
-              computed = 'blake3:' + blake3.blake3(canonical_for_hash(data)).hexdigest()
-              if stored != computed:
-                  print(f'  FAIL: {f.name}: stored={stored[:30]}... computed={computed[:30]}...')
-                  exit(1)
-              print(f'  OK: {f.name}')
-          print('All hashes verified')
-          "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,39 +10,28 @@ permissions:
   contents: read
 
 jobs:
-  validate-json:
+  validate-rules:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-          cache: 'pip'
-      - name: Install dependencies
-        run: pip install -r requirements.txt
-      - name: Validate entity JSONs against bootstrap schema
-        run: |
-          python3 -c "
-          import json
-          from jsonschema import validate
-          from pathlib import Path
-          schema = json.loads(Path('rules/core/_schema/bootstrap.schema.json').read_text())
-          for f in sorted(f for f in Path('rules/core').glob('*.json') if f.name != 'realm.json'):
-              validate(instance=json.loads(f.read_text()), schema=schema)
-              print(f'  OK: {f.name}')
-          "
-      - name: Validate realm.json against realm schema
-        run: |
-          python3 -c "
-          import json
-          from jsonschema import validate
-          from pathlib import Path
-          schema = json.loads(Path('rules/core/_schema/realm.v1.schema.json').read_text())
-          data = json.loads(Path('rules/core/realm.json').read_text())
-          validate(instance=data, schema=schema)
-          print('  OK: realm.json')
-          "
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-strspc
+      - name: Validate realm and entity files
+        run: strspc-manager realm-lint rules/core/
+      - name: Diff rules (pull_request)
+        if: github.event_name == 'pull_request'
+        run: strspc diff rules/core/ --pr ${{ github.event.pull_request.number }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Diff rules (push)
+        if: >-
+          github.event_name == 'push'
+          && github.event.before != '0000000000000000000000000000000000000000'
+        run: strspc diff rules/core/ --base ${{ github.event.before }}
 
   lint-commits:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,26 +21,24 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - uses: ./.github/actions/setup-strspc
+
+      - name: Validate realm and entity files
+        run: strspc-manager realm-lint rules/core/
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           cache: 'pip'
+
       - name: Install dependencies
         run: pip install -r requirements.txt
-      - name: Pre-flight validation (JSON schema)
+
+      - name: Pre-flight schema staleness check
         run: python3 tools/build-schema.py --check
-      - name: Validate realm.json
-        run: |
-          python3 -c "
-          import json
-          from jsonschema import validate
-          from pathlib import Path
-          schema = json.loads(Path('rules/core/_schema/realm.v1.schema.json').read_text())
-          data = json.loads(Path('rules/core/realm.json').read_text())
-          validate(instance=data, schema=schema)
-          print('  OK: realm.json')
-          "
+
       - name: Bump version and create tag
         id: tag
         uses: mathieudutour/github-tag-action@v6.2
@@ -48,12 +46,14 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: patch
           tag_prefix: v
+
       - name: Package rules
         run: |
           VERSION="${{ steps.tag.outputs.new_tag }}"
           VERSION_BARE="${VERSION#v}"
           tar -czf "strspc-rules-${VERSION_BARE}.tar.gz" rules/ LICENSE NOTICE
           zip -r "strspc-rules-${VERSION_BARE}.zip" rules/ LICENSE NOTICE
+
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,11 +48,11 @@ violate. **Always prefer CLI commands over direct JSON editing.**
 - Realm management: `strspc realm init`, `strspc realm add`, `strspc realm validate`,
   `strspc realm dep add/remove`
 - Validation: `strspc lint`, `strspc render`
+- PR validation: `strspc diff`
 
 ### Not yet available (manual edit with human approval)
 
 - Rule lifecycle: `strspc rule add/update/promote/retire/abandon/supersede`
-- PR validation: `strspc diff`
 
 ### Manual edit checklist (when CLI doesn't support the operation)
 
@@ -140,7 +140,7 @@ pre-commit install  # also install the pre-commit stage hooks
 
 - Feature branches → `develop` via PR. `develop` → `main` via PR for releases.
 - Use `bd` (beads) for ALL task tracking — no markdown TODOs.
-- CI gates every PR — the `validate-json`, `build-schema`, `lint-python`, `lint-commits`,
+- CI gates every PR — the `validate-rules`, `build-schema`, `lint-python`, `lint-commits`,
   and `lint` jobs must all pass.
 - To release: open a PR from `develop` to `main`. On merge, the release workflow
   automatically bumps the semver tag based on conventional commit types (`feat`→minor,


### PR DESCRIPTION
## Summary

- Replace inline Python `jsonschema`/`blake3` validation in CI with `strspc-manager realm-lint` and `strspc-cli diff`
- Create reusable composite action with SHA-256 checksum verification for binary installation
- Strict superset of previous validation: 4 checks replaced, 17 new checks gained, 0 lost

## Changes

From PR #43 (merged to develop):

| File | Change |
|------|--------|
| `.github/actions/setup-strspc/action.yml` | New composite action with checksum verification |
| `.github/workflows/ci.yml` | `validate-json` → `validate-rules` with realm-lint + diff |
| `.github/workflows/build-schema.yml` | Inline Python → realm-lint; kept `build-schema.py --check` |
| `.github/workflows/release.yml` | Added realm-lint pre-flight |
| `AGENTS.md` | `strspc diff` now available; CI job name updated |

## Test plan

- [x] All CI checks pass on PR #43
- [x] Copilot code review addressed (checksum verification added)
- [x] Upstream hash fix released (strspc-manager v1.14.1, strspc-cli v1.14.1)

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)